### PR TITLE
store html in database

### DIFF
--- a/App/Models/News.hs
+++ b/App/Models/News.hs
@@ -9,14 +9,16 @@ module App.Models.News (
 ) where
 
 import Database.PostgreSQL.ORM
+import Database.PostgreSQL.Fields ()
 import GHC.Generics
 import Data.Text
+import Text.Blaze.Html5
 
 data News = News {
   id :: DBKey,
   title :: Text,
   short :: Text,
-  content :: Text
+  content :: Html
 } deriving Generic
 
 instance Model News

--- a/App/Views/News.hs
+++ b/App/Views/News.hs
@@ -36,5 +36,4 @@ show :: News -> H.Html
 show news = appLayout $ toHtml $
   H.div ! A.class_ "news_standalone" $ do
     H.h1 ! A.class_ "news__title" $ toHtml $ News.title news
-    H.div ! A.class_ "news__content" $
-      H.preEscapedText $ News.content news
+    H.div ! A.class_ "news__content" $ News.content news

--- a/happ.cabal
+++ b/happ.cabal
@@ -61,11 +61,13 @@ executable happ
   other-extensions:  OverloadedStrings
                     ,ScopedTypeVariables
                     ,DeriveGeneric
+                    ,TypeSynonymInstances
 
   -- Other library packages from which modules are imported.
   build-depends:       base >=4.7 && <4.8
                       ,happstack-server
                       ,blaze-html
+                      ,blaze-markup
                       ,process
                       ,postgresql-simple
                       ,postgresql-orm

--- a/lib/Database/PostgreSQL/Fields.hs
+++ b/lib/Database/PostgreSQL/Fields.hs
@@ -1,0 +1,25 @@
+{-# LANGUAGE TypeSynonymInstances #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+module Database.PostgreSQL.Fields ()
+where
+
+import Database.PostgreSQL.Simple.FromField
+import Database.PostgreSQL.Simple.ToField
+import Control.Applicative
+import Text.Blaze.Html5
+import Text.Blaze.Html.Renderer.Text
+import Data.Text.Encoding
+import Database.PostgreSQL.Simple.TypeInfo.Static as TI
+
+instance FromField Html where
+  fromField f mdata =
+      if typeOid f /= typoid TI.text
+        then returnError Incompatible f ""
+        else case mdata of
+               Nothing  -> returnError UnexpectedNull f ""
+               Just dat -> pure $ preEscapedText $ decodeUtf8 dat
+
+instance ToField Html where
+  toField = toField . renderHtml


### PR DESCRIPTION
implented `HTML` field type, which would auto convert html-safe values
